### PR TITLE
Intake class and CANrange

### DIFF
--- a/src/main/java/frc/robot/Robot.kt
+++ b/src/main/java/frc/robot/Robot.kt
@@ -3,7 +3,6 @@
 // the WPILib BSD license file in the root directory of this project.
 package frc.robot
 
-import edu.wpi.first.units.Units.Inches
 import edu.wpi.first.wpilibj.TimedRobot
 import edu.wpi.first.wpilibj.smartdashboard.Mechanism2d
 import edu.wpi.first.wpilibj.smartdashboard.MechanismLigament2d

--- a/src/main/java/frc/robot/Robot.kt
+++ b/src/main/java/frc/robot/Robot.kt
@@ -3,6 +3,7 @@
 // the WPILib BSD license file in the root directory of this project.
 package frc.robot
 
+import edu.wpi.first.units.Units.Inches
 import edu.wpi.first.wpilibj.TimedRobot
 import edu.wpi.first.wpilibj.smartdashboard.Mechanism2d
 import edu.wpi.first.wpilibj.smartdashboard.MechanismLigament2d

--- a/src/main/java/frc/robot/subsystems/Intake.kt
+++ b/src/main/java/frc/robot/subsystems/Intake.kt
@@ -1,32 +1,31 @@
 package frc.robot.subsystems
 
-import edu.wpi.first.wpilibj2.command.Subsystem
 import com.ctre.phoenix6.hardware.CANrange
 import edu.wpi.first.units.Units
-import edu.wpi.first.units.measure.Distance
+import edu.wpi.first.wpilibj2.command.Subsystem
 
 object Intake : Subsystem {
-    val canRange : CANrange = CANrange(0)
+    val canRange: CANrange = CANrange(0)
 
     // TODO: Change this value for actual robot.
     val sidePlateThickness = 1.25 // Measured in cm.
 
-    var hasCoral : Boolean = false
+    var hasCoral: Boolean = false
 
-    fun hasCoral() : Boolean {
-        return canRange.getIsDetected().value;
+    fun hasCoral(): Boolean {
+        return canRange.getIsDetected().value
     }
 
     // Returns the distance from the sensor to the nearest object's edge.
     // Usually returns around +/- 1cm.
-    fun distance() : Double {
+    fun distance(): Double {
         var original = canRange.getDistance().value.`in`(Units.Centimeter)
 
         return original - offsetError(original) - sidePlateThickness
     }
 
     // Adjusts the distance value from the sensor to counter its error.
-    private fun offsetError(original: Double) : Double {
-        return -0.0014 * (original*original) + (0.0854 * original) + 2.9723
+    private fun offsetError(original: Double): Double {
+        return -0.0014 * (original * original) + (0.0854 * original) + 2.9723
     }
 }

--- a/src/main/java/frc/robot/subsystems/Intake.kt
+++ b/src/main/java/frc/robot/subsystems/Intake.kt
@@ -1,5 +1,32 @@
 package frc.robot.subsystems
 
 import edu.wpi.first.wpilibj2.command.Subsystem
+import com.ctre.phoenix6.hardware.CANrange
+import edu.wpi.first.units.Units
+import edu.wpi.first.units.measure.Distance
 
-object Intake : Subsystem {}
+object Intake : Subsystem {
+    val canRange : CANrange = CANrange(0)
+
+    // TODO: Change this value for actual robot.
+    val sidePlateThickness = 1.25 // Measured in cm.
+
+    var hasCoral : Boolean = false
+
+    fun hasCoral() : Boolean {
+        return canRange.getIsDetected().value;
+    }
+
+    // Returns the distance from the sensor to the nearest object's edge.
+    // Usually returns around +/- 1cm.
+    fun distance() : Double {
+        var original = canRange.getDistance().value.`in`(Units.Centimeter)
+
+        return original - offsetError(original) - sidePlateThickness
+    }
+
+    // Adjusts the distance value from the sensor to counter its error.
+    private fun offsetError(original: Double) : Double {
+        return -0.0014 * (original*original) + (0.0854 * original) + 2.9723
+    }
+}


### PR DESCRIPTION
Added to Intake subsystem:

- Coral distance from inner edge of side plate.
- Boolean check to see if coral is in intake.
- Error correction for CANrange (-0.0014x^2+0.0854x+2.9723).