### PR TITLE
Use path planner to align to branches

### DIFF
--- a/src/main/java/frc/robot/Robot.kt
+++ b/src/main/java/frc/robot/Robot.kt
@@ -4,7 +4,7 @@
 package frc.robot
 
 import com.ctre.phoenix6.SignalLogger
-import com.pathplanner.lib.commands.PathfindingCommand
+import com.pathplanner.lib.commands.FollowPathCommand
 import edu.wpi.first.apriltag.AprilTagFieldLayout
 import edu.wpi.first.apriltag.AprilTagFields
 import edu.wpi.first.hal.FRCNetComm
@@ -149,7 +149,7 @@ object Robot : LoggedRobot() {
         // it,
         // but the lowest safe limit is greater than this due to the top elevator supports
         Wrist.initializePosition()
-        PathfindingCommand.warmupCommand().schedule()
+        FollowPathCommand.warmupCommand().schedule()
     }
 
     private val autoChooser =

--- a/src/main/java/frc/robot/Robot.kt
+++ b/src/main/java/frc/robot/Robot.kt
@@ -167,14 +167,22 @@ object Robot : LoggedRobot() {
 
     override fun simulationInit() {
         // Create a mechanism widget
-        val robot = Mechanism2d(150.0, 100.0)
+        val robot = Mechanism2d(1.0, 5.0)
         // The pivot axis location is the root of the mechanism
         // This puts it at 5 units from the left and 5 units from the bottom of the widget
-        val pivot = robot.getRoot("pivot", 75.0, 5.0)
+        val pivot = robot.getRoot("pivot", .25, 0.25)
         // The elevator gets attached to the pivot. It starts with a length of 30, and an angle of 4
         // degrees
         elevatorMech =
-            pivot.append(MechanismLigament2d("elevator", 30.0, 45.0, 4.0, Color8Bit(Color.kOrange)))
+            pivot.append(
+                MechanismLigament2d(
+                    "elevator",
+                    30.0.inches.meters,
+                    45.0,
+                    4.0,
+                    Color8Bit(Color.kOrange),
+                )
+            )
         // The wrist gets attached to the elevator. It starts with a length of 20, and an angle of
         // 90.
         // This angle is relative to the elevator, so it will point straight up when the elevator is
@@ -182,9 +190,17 @@ object Robot : LoggedRobot() {
         // to the left when the elevator is at 90º
         wristMech =
             elevatorMech.append(
-                MechanismLigament2d("wrist", 12.0, 90.0, 6.0, Color8Bit(Color.kPurple))
+                MechanismLigament2d(
+                    "wrist",
+                    12.0.inches.meters,
+                    90.0,
+                    6.0,
+                    Color8Bit(Color.kPurple),
+                )
             )
-        wristMech.append(MechanismLigament2d("coral", 6.25, 112.0, 6.0, Color8Bit(Color.kWhite)))
+        wristMech.append(
+            MechanismLigament2d("coral", 6.25.inches.meters, 112.0, 6.0, Color8Bit(Color.kWhite))
+        )
 
         // Put the mechanism widget with all its components on the dashboard,
         SmartDashboard.putData("robot", robot)
@@ -204,7 +220,7 @@ object Robot : LoggedRobot() {
         elevatorMech.angle = Pivot.angle.degrees
         // Elevator.length is 0 when the elevator is retracted, but the elevator has a fixed length
         // of 30 inches
-        elevatorMech.length = (30.inches + Elevator.position).inches
+        elevatorMech.length = (30.inches + Elevator.position).meters
         wristMech.angle = 140 - Wrist.angle.degrees
     }
 

--- a/src/main/java/frc/robot/auto/Autos.kt
+++ b/src/main/java/frc/robot/auto/Autos.kt
@@ -21,7 +21,6 @@ import frc.robot.subsystems.SuperStructure
 import frc.robot.subsystems.SuperStructure.retractWithAlgae
 import frc.robot.subsystems.Wrist
 import frc.robot.subsystems.drivetrain.Chassis
-import frc.robot.subsystems.drivetrain.Chassis.alignmentDebouncer
 
 object Autos {
 

--- a/src/main/java/frc/robot/auto/Autos.kt
+++ b/src/main/java/frc/robot/auto/Autos.kt
@@ -1,13 +1,11 @@
 package frc.robot.auto
 
-import edu.wpi.first.math.filter.Debouncer
 import edu.wpi.first.wpilibj2.command.Command
 import edu.wpi.first.wpilibj2.command.Commands
 import edu.wpi.first.wpilibj2.command.WaitUntilCommand
 import frc.robot.commands.scoreCoralWhenClose
 import frc.robot.lib.FieldPoses
 import frc.robot.lib.FieldPoses.Branch
-import frc.robot.lib.andWait
 import frc.robot.lib.command
 import frc.robot.subsystems.Elevator
 import frc.robot.subsystems.Intake
@@ -23,6 +21,7 @@ import frc.robot.subsystems.SuperStructure
 import frc.robot.subsystems.SuperStructure.retractWithAlgae
 import frc.robot.subsystems.Wrist
 import frc.robot.subsystems.drivetrain.Chassis
+import frc.robot.subsystems.drivetrain.Chassis.alignmentDebouncer
 
 object Autos {
 
@@ -43,8 +42,6 @@ object Autos {
             Intake.intakeCoralThenHold().deadlineFor(Chassis.driveToClosestCenterCoralStation),
         )
     }
-
-    private val alignmentDebouncer = Debouncer(0.1, Debouncer.DebounceType.kRising) // was 0.5
 
     @Suppress("SpreadOperator")
     val SideCoralFast by command {
@@ -94,19 +91,16 @@ object Autos {
 
     private val scoreAlgaeInBarge by command {
         // Drive to barge
-        Chassis.driveToBargeRight.withDeadline(
-            Commands.sequence(
-                Commands.waitUntil { Chassis.isWithinGoal(1.5) },
-                SuperStructure.smartGoTo(AlgaeNet).andWait {
-                    alignmentDebouncer.calculate(Chassis.isWithinGoal(0.06))
-                },
-                SuperStructure.autoScoreAlgaeInNet,
+        Chassis.driveToBargeRight
+            .alongWith(
+                Commands.waitUntil { Chassis.isWithinGoal(1.5) }
+                    .andThen(SuperStructure.smartGoTo(AlgaeNet))
             )
-        )
+            .andThen(SuperStructure.autoScoreAlgaeInNet)
     }
 
     private fun getAlgaeAndScore(face: FieldPoses.ReefFace) =
-        Chassis.driveToPose { face.pose }
+        Chassis.pathplanToPose { face.pose }
             .withDeadline(
                 // Get algae
                 Commands.waitUntil { Chassis.isWithinGoal(1.5) }
@@ -115,7 +109,7 @@ object Autos {
             .andThen(scoreAlgaeInBarge)
 
     private fun getHighAlgaeAndScore(face: FieldPoses.ReefFace) =
-        Chassis.driveToPose { face.pose }
+        Chassis.pathplanToPose { face.pose }
             .withDeadline(
                 // Get algae
                 Commands.sequence(

--- a/src/main/java/frc/robot/lib/ControllerDrive.kt
+++ b/src/main/java/frc/robot/lib/ControllerDrive.kt
@@ -18,7 +18,7 @@ private const val DOWN_ADJUST = 0.55 // changed from 0.4 at 1821 3/8
 private const val JOYSTICK_DEADBAND = 0.1
 private const val TRIGGER_DEADBAND = 0.05
 private val maxTranslation = 4.0.metersPerSecond
-private val maxRotation = 1.rotationsPerSecond
+private val maxRotation = 1.5.rotationsPerSecond
 
 /* Extension properties to access the drive velocities based on joystick input
  * This used to be a single method that returned a ChassisSpeeds object,

--- a/src/main/java/frc/robot/lib/FieldPoses.kt
+++ b/src/main/java/frc/robot/lib/FieldPoses.kt
@@ -11,6 +11,7 @@ import frc.robot.Robot
 import frc.robot.Robot.alliance
 import frc.robot.subsystems.drivetrain.Chassis
 import kotlin.jvm.optionals.getOrNull
+import kotlin.math.abs
 
 /** Poses that the robot can auto-align to */
 object FieldPoses {
@@ -171,15 +172,19 @@ object FieldPoses {
 
     //    private val PROCESSOR_TO_BOT = Transform2d(0.9.meters, 0.2.meters,
     // Rotation2d.fromDegrees(203.0)) // TODO need to test still
-    private val PROCESSOR_TO_BOT = Transform2d(0.9.meters, 0.0.meters, Rotation2d.k180deg)
+    private val PROCESSOR_TO_BOT = Transform2d(0.5.meters, 0.0.meters, Rotation2d.k180deg)
 
     private val PROCESSOR_POSES =
         intArrayOf(3, 16).map {
             Robot.gameField.getTagPose(it).get().toPose2d().transformBy(PROCESSOR_TO_BOT)
         }
 
+    /**
+     * Closest processor based on x-position on field. This makes the closest processor the one that
+     * is on the same half of the field as the robot
+     */
     val closestProcessor: Pose2d
-        get() = Chassis.state.Pose.nearest(PROCESSOR_POSES)
+        get() = PROCESSOR_POSES.minBy { abs(it.x - Chassis.state.Pose.x) }
 
     // Offset from the april tag coordinate to where the robot needs to be to score/align
     private val BARGE_TO_BOT = Transform2d(0.62.meters, 0.0.meters, Rotation2d.kZero) // 0.5922

--- a/src/main/java/frc/robot/lib/bindings/DriveBindings.kt
+++ b/src/main/java/frc/robot/lib/bindings/DriveBindings.kt
@@ -146,7 +146,7 @@ private fun CommandXboxController.configureDriveAutomaticSequencingLayout() {
     b().whileTrue(
             Chassis.driveToProcessor
                 .andThen(Intake.dropAlgae)
-                .andThen(Chassis.backAwayFromProcessor)
+                .andThen(Chassis.backAwayFromProcessor.until { Chassis.isWithinGoal(0.05) })
                 .andThen(SuperStructure.smartGoTo(RobotState.Stow).asProxy())
         )
         // Once at approach point, move to processor position
@@ -232,6 +232,7 @@ private fun CommandXboxController.configureBargeAlignments() {
                 Commands.waitUntil { Chassis.isWithinGoal(0.06) && SuperStructure.atPosition }
                     .andThen(Intake.scoreAlgae)
             )
+            .andThen(SuperStructure.smartGoTo(RobotState.Stow))
             .onlyIf { Intake.detectAlgaeByCurrent() }
     }
     // only y

--- a/src/main/java/frc/robot/subsystems/Climber.kt
+++ b/src/main/java/frc/robot/subsystems/Climber.kt
@@ -4,6 +4,7 @@ import com.ctre.phoenix6.configs.TalonFXConfiguration
 import com.ctre.phoenix6.controls.PositionVoltage
 import com.ctre.phoenix6.hardware.TalonFX
 import com.ctre.phoenix6.signals.InvertedValue
+import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard
 import edu.wpi.first.wpilibj2.command.SubsystemBase
 import frc.robot.lib.command
 import frc.robot.lib.rotations
@@ -45,6 +46,10 @@ object Climber : SubsystemBase("climber") {
     }
 
     val retract by command { runOnce { setpoint = 0.rotations }.withName("Retract foot") }
+
+    init {
+        SmartDashboard.putData(retract)
+    }
 
     val extend by command { runOnce { setpoint = extendedPosition }.withName("Extend Foot") }
 }

--- a/src/main/java/frc/robot/subsystems/Intake.kt
+++ b/src/main/java/frc/robot/subsystems/Intake.kt
@@ -165,6 +165,7 @@ object Intake : SubsystemBase("intake") {
     val scoreAlgae by command {
         outtakeAlgae { if (Elevator.position.meters <= 0.2) 0.2 else 1.0 }.withTimeout(0.5.seconds)
     }
+    val dropAlgae by command { outtakeAlgae { 0.1 }.withTimeout(0.1) }
 
     private val coralDetectedDebounce = Debouncer(0.1, Debouncer.DebounceType.kRising)
 

--- a/src/main/java/frc/robot/subsystems/SuperStructure.kt
+++ b/src/main/java/frc/robot/subsystems/SuperStructure.kt
@@ -17,14 +17,14 @@ import frc.robot.subsystems.drivetrain.Chassis
 enum class RobotState(val pivotAngle: Angle, val elevatorHeight: Distance, val wristAngle: Angle) {
     Stow(40.degrees, 0.25.inches, 22.5.degrees),
     AlgaeStorage(60.degrees, 0.25.inches, 22.5.degrees),
-    L1(40.degrees, 0.25.inches, 186.75.degrees),
-    L2(93.5.degrees, 0.25.inches, 38.degrees),
-    L3(92.6.degrees, 17.25.inches, 38.degrees),
+    L1(38.degrees, 0.25.inches, 186.75.degrees),
+    L2(93.5.degrees, 0.25.inches, 37.degrees),
+    L3(92.6.degrees, 17.25.inches, 36.degrees),
     L4(92.5.degrees, 46.inches, 29.25.degrees),
     CoralStation(62.92.degrees, 0.25.inches, 176.degrees),
-    NewCoralStation(69.1.degrees, 0.1.inches, 185.8.degrees), // pivot 68.2
-    AlgaeGroundPickup(30.degrees, 0.25.inches, 181.35.degrees),
-    Processor(23.degrees, 0.25.inches, 113.625.degrees),
+    NewCoralStation(67.1.degrees, 0.1.inches, 185.8.degrees), // pivot 68.2
+    AlgaeGroundPickup(26.degrees, 0.25.inches, 181.35.degrees),
+    Processor(10.7.degrees, 0.25.inches, 86.4.degrees),
     HighAlgaeIntake(100.2.degrees, 19.33.inches, 13.25.degrees),
     LowAlgaeIntake(104.degrees, 0.25.inches, 19.2125.degrees),
     AlgaeNet(91.degrees, 53.5.inches, 47.7675.degrees),

--- a/src/main/java/frc/robot/subsystems/SuperStructure.kt
+++ b/src/main/java/frc/robot/subsystems/SuperStructure.kt
@@ -138,7 +138,7 @@ object SuperStructure {
             goToSelectedLevel,
             Commands.waitUntil { atPosition },
             Intake.scoreCoral,
-            smartGoTo(RobotState.CoralStation),
+            smartGoTo(RobotState.Stow),
         )
     }
 

--- a/src/main/java/frc/robot/subsystems/Wrist.kt
+++ b/src/main/java/frc/robot/subsystems/Wrist.kt
@@ -44,7 +44,7 @@ object Wrist : SubsystemBase("wrist") {
     private val ALPHA_BOT_MOTOR_OUTPUT_CONFIG =
         MotorOutputConfigs()
             .withNeutralMode(NeutralModeValue.Coast)
-            .withInverted(InvertedValue.CounterClockwise_Positive)
+            .withInverted(InvertedValue.Clockwise_Positive)
 
     private val COMP_BOT_MOTOR_OUTPUT_CONFIG =
         MotorOutputConfigs()
@@ -85,16 +85,16 @@ object Wrist : SubsystemBase("wrist") {
     private val motionMagic =
         DynamicMotionMagicVoltage(
             0.degrees,
-            10.rotationsPerSecond,
-            30.rotationsPerSecondPerSecond,
-            100.rotationsPerSecondCubed,
+            1.rotationsPerSecond,
+            3.rotationsPerSecondPerSecond,
+            0.rotationsPerSecondCubed,
         )
 
     private val leader = TalonFX(13, "*").apply { configurator.apply(standardConfig) }
 
     private val shouldLimitReverseMotion: Boolean
         get() {
-            return Pivot.angle < 20.degrees
+            return Pivot.angle < 20.degrees && angle > 90.degrees
         }
 
     val atPosition
@@ -195,9 +195,9 @@ object Wrist : SubsystemBase("wrist") {
         // Command the wrist to move to the setpoint
         motionMagic.withPosition(setpoint).withLimitReverseMotion(shouldLimitReverseMotion)
         if (Intake.detectAlgaeByCurrent()) {
-            motionMagic.withVelocity(3.0).withAcceleration(6.0).withJerk(30.0)
+            motionMagic.withAcceleration(6.0)
         } else {
-            motionMagic.withVelocity(10.0).withAcceleration(30.0).withJerk(100.0)
+            motionMagic.withAcceleration(30.0)
         }
         leader.setControl(motionMagic)
     }

--- a/src/main/java/frc/robot/subsystems/drivetrain/Chassis.kt
+++ b/src/main/java/frc/robot/subsystems/drivetrain/Chassis.kt
@@ -486,7 +486,7 @@ object Chassis :
             // those values are
             ConstraintsZone(1.0, 2.0, PathConstraints(0.5, 5.0, 10.0, 100.0, 12.0))
         )
-    private val pathEventMarkers = listOf(EventMarker("atApproachPoint", 0.8))
+    private val pathEventMarkers = listOf(EventMarker("atApproachPoint", 1.0))
     private val pathConstraints =
         PathConstraints(
             4.metersPerSecond,


### PR DESCRIPTION
Previously we used a single PID controller to drive the robot directly to its final pose. This caused issues when aligning from the left or right, since the robot would move tangentially to the barge causing the coral to hit the branch.

Using pathplanner, we specify a constraint that forces the robot to drive to its final pose in the same direction it faces, i.e head on. This behavior prevents the coral from being knocked out of place when aligning from close to the reef.

This PR also adds the auto-scoring processor sequence, which relies on this behavior. The sequence drives the robot into the processor and releases the algae. It needs to drive in head on to avoid colliding with the side walls.

Autos remain untouched, since the nature of the pathing will add time and we didn't test them with the new logic. It would be worth doing for more robust alignment though. 