### PR TITLE
Fix algae over-intake issue

### DIFF
--- a/src/main/java/frc/robot/lib/bindings/DriveBindings.kt
+++ b/src/main/java/frc/robot/lib/bindings/DriveBindings.kt
@@ -173,8 +173,8 @@ private fun CommandXboxController.configureDriveAutomaticSequencingLayout() {
 private fun CommandXboxController.configureReefAlignments() {
     val notLeftBumper = leftBumper().negate()
     val notRightBumper = rightBumper().negate()
-    val hasCoral = Trigger { Intake.hasBranchCoral }
-    val hasNoCoral = Trigger { !Intake.hasBranchCoral }
+    val hasCoral = Trigger { Intake.hasCoralByCurrent() }
+    val hasNoCoral = hasCoral.negate()
 
     rightBumper()
         .and(notLeftBumper)


### PR DESCRIPTION
I believe when the intake over-intakes the algae, the coral sensor trips. This caused
the coral scoring command to run due to the trigger sequence rising edge being tripped,
especially when scoring algae in the net

Changing to `hasCoralByCurrent` should prevent this as the torque current is negative
when an algae is being held, so the can range tripping won't be enough on its own
